### PR TITLE
Using or creating Docker container to run signalAlign

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,0 +1,29 @@
+# Basics
+FROM gcc:5.4
+FROM opentable/anaconda
+
+MAINTAINER Miten Jain, miten@soe.ucsc.edu
+
+# apt-get installs
+RUN apt-get update && apt-get install -y git make zlib1g-dev g++
+WORKDIR /home/
+
+# signalAlign
+RUN git clone --recursive https://github.com/artrand/signalAlign.git
+WORKDIR /home/signalAlign/
+RUN make
+
+# BWA
+RUN git clone https://github.com/lh3/bwa.git
+WORKDIR /home/signalAlign/bwa/
+RUN make
+WORKDIR /home/signalAlign/
+
+# set PATH variables
+ENV ROOT /home/signalAlign
+ENV PATH "$ROOT/bwa:$PATH"
+ENV PATH "$ROOT/bin:$PATH"
+
+# set signalAlign bin as workDir
+WORKDIR /home/signalAlign/bin/
+

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -27,3 +27,4 @@ ENV PATH "$ROOT/bin:$PATH"
 # set signalAlign bin as workDir
 WORKDIR /home/signalAlign/bin/
 
+

--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ These steps were tested in both a Linux and OS X Sierra environment using Docker
 https://docs.docker.com/installation/
 
 To download signalAlign Docker container:
-
-docker pull mitenjain/signalalign
+    
+    docker pull mitenjain/signalalign
 
 To run signalAlign from the container:
 
-docker run mitenjain/signalalign runSignalAlign
+    docker run mitenjain/signalalign runSignalAlign
 
 *Code in this repo is based on cPecan (https://github.com/benedictpaten/cPecan)*

--- a/README.md
+++ b/README.md
@@ -20,4 +20,13 @@ Nanopore sequencing is based on the principal of isolating a nanopore in a membr
 3. Test the installation by running `make test`
 4. All of the programs can be found in the `/bin/` directory
 
+### Using Docker
+These steps were tested in both a Linux and OS X Sierra environment using Docker: https://docs.docker.com/installation/
+
+To download signalAlign Docker container:
+docker pull mitenjain/signalalign
+
+To run signalAlign from the container:
+docker run mitenjain/signalalign runSignalAlign
+
 *Code in this repo is based on cPecan (https://github.com/benedictpaten/cPecan)*

--- a/README.md
+++ b/README.md
@@ -21,12 +21,15 @@ Nanopore sequencing is based on the principal of isolating a nanopore in a membr
 4. All of the programs can be found in the `/bin/` directory
 
 ### Using Docker
-These steps were tested in both a Linux and OS X Sierra environment using Docker: https://docs.docker.com/installation/
+These steps were tested in both a Linux and OS X Sierra environment using Docker: 
+https://docs.docker.com/installation/
 
 To download signalAlign Docker container:
+
 docker pull mitenjain/signalalign
 
 To run signalAlign from the container:
+
 docker run mitenjain/signalalign runSignalAlign
 
 *Code in this repo is based on cPecan (https://github.com/benedictpaten/cPecan)*


### PR DESCRIPTION
This merge allows usage of a Docker container to run signalAlign. If desired, users can create their own container using the included Dockerfile in Docker folder .
